### PR TITLE
Fix alt instance

### DIFF
--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -58,12 +58,8 @@ instance applicativeParser :: Applicative Parser where
   pure a = Parser (\s _ sc -> sc a s)
 
 instance altParser :: Alt Parser where
-  (<|>) p1 p2 = Parser (\s fc sc ->
-    unParser p1 s (\pos msg ->
-      if s.pos == pos
-      then unParser p2 s fc sc
-      else fc pos msg)
-      sc)
+  (<|>) p1 p2 = Parser \s fc sc ->
+    unParser p1 s (\pos msg -> unParser p2 s fc sc) sc
 
 instance plusParser :: Plus Parser where
   empty = fail "No alternative"


### PR DESCRIPTION
@paf31 I'm not 100% sure if this is right, but it works as I expect this way. The `s` (`PosString`) is shared between `p1` and `p2`, so if `p1` consumes input it is reset when going into `p2`.