### PR TITLE
fix alternative instance to satisfy parse (bc <|> bd) bd

### DIFF
--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -58,12 +58,8 @@ instance applicativeParser :: Applicative Parser where
   pure a = Parser (\s _ sc -> sc a s)
 
 instance altParser :: Alt Parser where
-  alt p1 p2 = Parser (\s fc sc ->
-    unParser p1 s (\pos msg ->
-      if s.pos == pos
-      then unParser p2 s fc sc
-      else fc pos msg)
-      sc)
+  alt p1 p2 = Parser (\s fc sc -> 
+    unParser p1 s (\_ _ -> unParser p2 s fc sc) sc)
 
 instance plusParser :: Plus Parser where
   empty = fail "No alternative"

--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -58,8 +58,12 @@ instance applicativeParser :: Applicative Parser where
   pure a = Parser (\s _ sc -> sc a s)
 
 instance altParser :: Alt Parser where
-  alt p1 p2 = Parser (\s fc sc -> 
-    unParser p1 s (\_ _ -> unParser p2 s fc sc) sc)
+  alt p1 p2 = Parser (\s fc sc ->
+    unParser p1 s (\pos msg ->
+      if s.pos == pos
+      then unParser p2 s fc sc
+      else fc pos msg)
+      sc)
 
 instance plusParser :: Plus Parser where
   empty = fail "No alternative"

--- a/src/Text/Parsing/StringParser/String.purs
+++ b/src/Text/Parsing/StringParser/String.purs
@@ -54,7 +54,15 @@ anyDigit = try do
 string :: String -> Parser String
 string nt = Parser (\s fc sc -> case s of
   { str = str, pos = i } | indexOf' nt i str == Just i -> sc nt { str: str, pos: i + length nt }
-  { pos = i } -> fc i (ParseError $ "Expected '" ++ nt ++ "'."))
+  { str = str, pos = i } ->
+          let pref = commonPrefix 0 i str
+              msg = "Expected '" ++ nt ++ "', failed after " ++ show pref ++ " chars."
+           in fc (i + pref) (ParseError msg))
+  where
+  commonPrefix offset distance str =
+    if charAt offset nt == charAt (offset + distance) str
+       then commonPrefix (offset + 1) distance str
+       else offset
 
 -- | Match a character satisfying the given predicate.
 satisfy :: (Char -> Boolean) -> Parser Char

--- a/src/Text/Parsing/StringParser/String.purs
+++ b/src/Text/Parsing/StringParser/String.purs
@@ -104,8 +104,8 @@ upperCaseChar = do
 
 -- | Match any letter.
 anyLetter :: Parser Char
-anyLetter = lowerCaseChar <|> upperCaseChar <?> "Expected a letter"
+anyLetter = try lowerCaseChar <|> upperCaseChar <?> "Expected a letter"
 
 -- | Match a letter or a number.
 alphaNum :: Parser Char
-alphaNum = anyLetter <|> anyDigit <?> "Expected a letter or a number"
+alphaNum = try anyLetter <|> anyDigit <?> "Expected a letter or a number"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -77,4 +77,7 @@ main = do
   parseTest alphaNum "A"
   parseTest alphaNum "a"
   parseTest alphaNum "1"
-  parseTest (string "bc" <|> string "bd") "bd"
+  parseTest (try lowerCaseChar <|> upperCaseChar) "U"
+  parseTest (string "a" <|> string "ok") "ok"
+  parseTest (string "failure at 2 chars" <|> string "fawat") "fano"
+  parseTest (try (string "no") <|> string "ok") "ok"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -75,4 +75,6 @@ main = do
   parseTest (many1 anyDigit) "01234/" 
   parseTest (many1 anyDigit) "56789:" 
   parseTest alphaNum "A"
+  parseTest alphaNum "a"
+  parseTest alphaNum "1"
   parseTest (string "bc" <|> string "bd") "bd"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -72,3 +72,5 @@ main = do
   parseTest opTest "a+b+c"
   parseTest exprTest "1*2+3/4-5"
   parseTest tryTest "aacc"
+  parseTest alphaNum "A"
+  parseTest (string "bc" <|> string "bd") "bd"


### PR DESCRIPTION
Fixes #15 

Changes behaviour to match Attoparsec:

``` haskell
import Control.Applicative
import Data.Attoparsec.Text
main = print $ parse ("bc" <|> "bd") "bd"
```
