### PR TITLE
fix overflow caused by manyTill implementation

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,7 +7,9 @@ import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE)
 
 import Data.Either (isLeft, isRight, Either(..))
+import Data.Foldable (fold)
 import Data.List (List(Nil), (:))
+import Data.List.Lazy (take, repeat)
 import Data.String (joinWith, singleton)
 import Data.Unfoldable (replicate)
 
@@ -90,3 +92,7 @@ main = do
   assert $ expectResult Nil (manyTill (string "a") (string "b")) "b"
   assert $ expectResult ("a":"a":"a":Nil)  (many1Till (string "a") (string "b")) "aaab"
   assert $ parseFail (many1Till (string "a") (string "b")) "b"
+  -- check against overflow
+  assert $ canParse (many1Till (string "a") (string "and")) $ (fold <<< take 10000 $ repeat "a") <> "and"
+  -- check correct order
+  assert $ expectResult ('a':'b':'c':Nil)  (many1Till anyChar (string "d")) "abcd"


### PR DESCRIPTION
Ran into this the other day with a really long string. Maybe some of the other methods might be useful to look into, but the `many` implementation already uses `manyRec` and whatnot.

I also tried to use untilM' from monad-rec-loops but on my desktop, it's just way too slow (average ~8x slower):

normal:

```
C:\Users\justin\Code\purescript-string-parsers [fix-manyTill-overflow ≡]> Measure-Command {pulp test}
* Building project in C:\Users\justin\Code\purescript-string-parsers
* Build successful.
* Running tests...
* Tests OK.


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 2
Milliseconds      : 102
Ticks             : 21023247
TotalDays         : 2.43324618055556E-05
TotalHours        : 0.000583979083333333
TotalMinutes      : 0.035038745
TotalSeconds      : 2.1023247
TotalMilliseconds : 2102.3247
```

with rec-loops `untilM' p $ end *> pure true <|> pure false`:

```
C:\Users\justin\Code\purescript-string-parsers [fix-manyTill-overflow ≡]> Measure-Command {pulp test}
* Building project in C:\Users\justin\Code\purescript-string-parsers
Compiling Text.Parsing.StringParser.Expr
Compiling Text.Parsing.StringParser.String
Compiling Test.Main
* Build successful.
* Running tests...
* Tests OK.


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 18
Milliseconds      : 694
Ticks             : 186943150
TotalDays         : 0.000216369386574074
TotalHours        : 0.00519286527777778
TotalMinutes      : 0.311571916666667
TotalSeconds      : 18.694315
TotalMilliseconds : 18694.315
```