### PR TITLE
added Semigroup instance for Parser a where a is a Semigroup

### DIFF
--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -3,6 +3,8 @@
 module Text.Parsing.StringParser where
 
 import Prelude
+
+import Control.Apply (lift2)
 import Control.MonadPlus (class MonadPlus, class MonadZero, class Alternative)
 import Control.Monad.Rec.Class (class MonadRec, tailRecM, Step(..))
 import Control.Plus (class Plus, class Alt)
@@ -99,5 +101,5 @@ fail msg = Parser \{ pos } -> Left { pos, error: ParseError msg }
 try :: forall a. Parser a -> Parser a
 try (Parser p) = Parser \(s@{ pos }) -> lmap (_ { pos = pos}) (p s)
 
-instance semigroupParser :: (Semigroup a) => Semigroup (Parser a) where
-  append parser1 parser2 = (<>) <$> parser1 <*> parser2
+instance semigroupParser :: Semigroup a => Semigroup (Parser a) where
+  append = lift2 append

--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -98,3 +98,6 @@ fail msg = Parser \{ pos } -> Left { pos, error: ParseError msg }
 -- | `try p` backtracks even if input was consumed.
 try :: forall a. Parser a -> Parser a
 try (Parser p) = Parser \(s@{ pos }) -> lmap (_ { pos = pos}) (p s)
+
+instance semigroupParser :: (Semigroup a) => Semigroup (Parser a) where
+  append parser1 parser2 = (<>) <$> parser1 <*> parser2

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -51,8 +51,9 @@ exprTest = buildExprParser [ [Infix (string "/" >>= \_ -> pure div) AssocRight]
 
 tryTest :: Parser String
             -- reduce the possible array of matches to 0 or 1 elements to aid Array pattern matching
-tryTest = try ((<>) <$> string "aa" <*> string "bb") <|>
-          (<>) <$> string "aa" <*> string "cc"
+tryTest = 
+  try ((string "aa" <> string "bb")) <|> 
+       (string "aa" <> string "cc")
 
 canParse :: forall a. Parser a -> String -> Boolean
 canParse p input = isRight $ runParser p input

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -52,8 +52,8 @@ exprTest = buildExprParser [ [Infix (string "/" >>= \_ -> pure div) AssocRight]
 tryTest :: Parser String
             -- reduce the possible array of matches to 0 or 1 elements to aid Array pattern matching
 tryTest = 
-  try ((string "aa" <> string "bb")) <|> 
-       (string "aa" <> string "cc")
+  try (string "aa" <> string "bb") <|> 
+      (string "aa" <> string "cc")
 
 canParse :: forall a. Parser a -> String -> Boolean
 canParse p input = isRight $ runParser p input


### PR DESCRIPTION
Hi,
I'm enjoying this library quite a bit, but I kept wishing there was a `Semigroup` instance for `Parser a` where `a` is a `Semigroup`, like there is in purescript-parsing, so I figured why not make a PR? 

I've added the instance and I modified the `tryTest` in the tests to use Semigroup syntax, which is a bit nicer.

I really appreciate all of the effort that has been put into this library, and I hope this is helpful!