### PR TITLE
get rid of usages of codepoints functions that are slow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Dependency status](https://img.shields.io/librariesio/github/purescript-contrib/purescript-string-parsers.svg)](https://libraries.io/github/purescript-contrib/purescript-string-parsers)
 [![Maintainer: paf31](https://img.shields.io/badge/maintainer-paf31-lightgrey.svg)](http://github.com/paf31)
 
-A parsing library for parsing strings.
+A parsing library for parsing strings using [Code Units](https://pursuit.purescript.org/packages/purescript-strings/docs/Data.String.CodeUnits) (JS Strings). Does not handle [Code Points](https://pursuit.purescript.org/packages/purescript-strings/docs/Data.String.CodePoints).
 
 This library is a simpler, faster alternative to `purescript-parsing`, for when you know your input will be a string.
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,8 +9,8 @@ import Data.List (List(Nil), (:))
 import Data.List.Lazy (take, repeat)
 import Data.List.NonEmpty (NonEmptyList(..))
 import Data.NonEmpty ((:|))
-import Data.String (joinWith)
 import Data.String.CodeUnits (singleton)
+import Data.String.Common as SC
 import Data.Unfoldable (replicate)
 import Effect (Effect)
 import Test.Assert (assert', assert)
@@ -66,11 +66,11 @@ expectResult res p input = runParser p input == Right res
 
 main :: Effect Unit
 main = do
-  assert' "many should not blow the stack" $ canParse (many (string "a")) (joinWith "" $ replicate 100000 "a")
+  assert' "many should not blow the stack" $ canParse (many (string "a")) (SC.joinWith "" $ replicate 100000 "a")
   assert' "many failing after" $ parseFail (do
     as <- many (string "a")
     eof
-    pure as) (joinWith "" (replicate 100000 "a") <> "b" )
+    pure as) (SC.joinWith "" (replicate 100000 "a") <> "b" )
 
   assert $ expectResult 3 nested "(((a)))"
   assert $ expectResult ("a":"a":"a":Nil)  (many (string "a")) "aaa"


### PR DESCRIPTION
Sorry, this is all my fault. I forgot to try to purge all usages of CodePoints functions before and ran into this when one of my parsers became 100x slower.