### PR TITLE
Fix transitive dependencies errors in spago 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ New features:
 
 Bugfixes:
 
-- Fix transitive dependencies errors found by latest spago (#71)
-
 Other improvements:
+- Fix transitive dependencies errors found by Spago 0.20 (#71 by @milesfrain)
 
 ## [v6.0.0](https://github.com/purescript-contrib/purescript-string-parsers/releases/tag/v6.0.0) - 2021-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ New features:
 
 Bugfixes:
 
+- Fix transitive dependencies errors found by latest spago (#71)
+
 Other improvements:
 
 ## [v6.0.0](https://github.com/purescript-contrib/purescript-string-parsers/releases/tag/v6.0.0) - 2021-02-26

--- a/spago.dhall
+++ b/spago.dhall
@@ -7,14 +7,16 @@
   , "control"
   , "effect"
   , "either"
+  , "enums"
   , "foldable-traversable"
   , "lists"
-  , "math"
   , "maybe"
+  , "nonempty"
   , "prelude"
   , "psci-support"
   , "strings"
   , "tailrec"
+  , "unfoldable"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/test/Examples.purs
+++ b/test/Examples.purs
@@ -42,6 +42,7 @@ exampleContent1 =
 
 numberOfAs :: Parser Int
 numberOfAs = do
+                                                                        {-
   let
     oneIfA = 1 <$ string "a" <?> "Letter was 'a'"
     zeroIfNotA = 0 <$ regex "[^a]" <?> "Letter was not 'a'"
@@ -49,7 +50,6 @@ numberOfAs = do
                             "The impossible happened: \
                             \a letter was not 'a', and was not not-'a'."
     convertLettersToList = many1 letterIsOneOrZero
-                                                                        {-
   list <- convertLettersToList                                          -}
   list <- many1
           (  (1 <$ string "a")


### PR DESCRIPTION
**Description of the change**

Fixes spago warnings when building and running tests for this library locally.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
