### PR TITLE
Run slowest tests last and print status updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ Bugfixes:
 
 Other improvements:
 
+- Run slowest tests last and print status updates (#72)
+
 ## [v6.0.1](https://github.com/purescript-contrib/purescript-string-parsers/releases/tag/v6.0.1) - 2021-05-11
 
 Other improvements:
-- Fix transitive dependencies errors found by Spago 0.20 (#71 by @milesfrain)
+- Fix transitive dependencies errors found by Spago 0.20 (#71)
 
 ## [v6.0.0](https://github.com/purescript-contrib/purescript-string-parsers/releases/tag/v6.0.0) - 2021-02-26
 

--- a/test/CodeUnits.purs
+++ b/test/CodeUnits.purs
@@ -13,11 +13,12 @@ import Data.String.CodeUnits (singleton)
 import Data.String.Common as SC
 import Data.Unfoldable (replicate)
 import Effect (Effect)
+import Effect.Class.Console (log)
 import Test.Assert (assert', assert)
 import Text.Parsing.StringParser (Parser, runParser, try)
+import Text.Parsing.StringParser.CodeUnits (anyDigit, eof, string, anyChar, regex)
 import Text.Parsing.StringParser.Combinators (many1, endBy1, sepBy1, optionMaybe, many, manyTill, many1Till, chainl, fix, between)
 import Text.Parsing.StringParser.Expr (Assoc(..), Operator(..), buildExprParser)
-import Text.Parsing.StringParser.CodeUnits (anyDigit, eof, string, anyChar, regex)
 
 parens :: forall a. Parser a -> Parser a
 parens = between (string "(") (string ")")
@@ -66,11 +67,8 @@ expectResult res p input = runParser p input == Right res
 
 testCodeUnits :: Effect Unit
 testCodeUnits = do
-  assert' "many should not blow the stack" $ canParse (many (string "a")) (SC.joinWith "" $ replicate 100000 "a")
-  assert' "many failing after" $ parseFail (do
-    as <- many (string "a")
-    eof
-    pure as) (SC.joinWith "" (replicate 100000 "a") <> "b" )
+
+  log "Running basic tests"
 
   assert $ expectResult 3 nested "(((a)))"
   assert $ expectResult ("a":"a":"a":Nil)  (many (string "a")) "aaa"
@@ -93,7 +91,16 @@ testCodeUnits = do
   assert $ expectResult Nil (manyTill (string "a") (string "b")) "b"
   assert $ expectResult (NonEmptyList ("a" :| "a":"a":Nil)) (many1Till (string "a") (string "b")) "aaab"
   assert $ parseFail (many1Till (string "a") (string "b")) "b"
-  -- check against overflow
-  assert $ canParse (many1Till (string "a") (string "and")) $ (fold <<< take 10000 $ repeat "a") <> "and"
   -- check correct order
   assert $ expectResult (NonEmptyList ('a' :| 'b':'c':Nil)) (many1Till anyChar (string "d")) "abcd"
+
+  log "Running overflow tests (may take a while)"
+
+  -- check against overflow
+  assert $ canParse (many1Till (string "a") (string "and")) $ (fold <<< take 10000 $ repeat "a") <> "and"
+
+  assert' "many should not blow the stack" $ canParse (many (string "a")) (SC.joinWith "" $ replicate 100000 "a")
+  assert' "many failing after" $ parseFail (do
+    as <- many (string "a")
+    eof
+    pure as) (SC.joinWith "" (replicate 100000 "a") <> "b" )


### PR DESCRIPTION
**Description of the change**

When I first ran tests locally in this repo, my system stalled for a minute at 100% CPU, which made me think something was wrong. Not sure if this is a real problem, or if parsing is just really slow for the stack overflow tests.

This PR moves the slower stack overflow tests to the end of each suite and prints some status messages to users.

```
time spago test                                                       

Compiling Test.Main
           Src   Lib   All
Warnings   0     0     0  
Errors     0     0     0  
[info] Build succeeded.
Testing CodePoint parsing

Running basic tests
Running overflow tests (may take a while)


Testing CodeUnit parsing

Running basic tests
Running overflow tests (may take a while)
[info] Tests succeeded.

spago test  122.84s user 1.35s system 102% cpu 2:01.65 total
```

Also, wondering if we should [configure actions to ignore readme files](https://stackoverflow.com/a/62972393) so updating the changlog doesn't unnecessarily re-trigger CI.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
