### PR TITLE
Add a simple benchmark module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 output
 generated-docs
 bower_components
+
+node_modules
+package.json
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Bugfixes:
 
 Other improvements:
 - Added `purs-tidy` formatter (#76 by @thomashoneyman)
-
+- Add a benchmark module (#79 by @chtenb)
 - Run slowest tests last and print status updates (#72)
 
 ## [v6.0.1](https://github.com/purescript-contrib/purescript-string-parsers/releases/tag/v6.0.1) - 2021-05-11

--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ You can contribute to `string-parsers` in several ways:
 2. If you would like to contribute code, tests, or documentation, please [read the contributor guide](./CONTRIBUTING.md). It's a short, helpful introduction to contributing to this library, including development instructions.
 
 3. If you have written a library, tutorial, guide, or other resource based on this package, please share it on the [PureScript Discourse](https://discourse.purescript.org)! Writing libraries and learning resources are a great way to help this library succeed.
+
+## Benchmark
+
+To execute the benchmarks run the following command
+
+```
+spago run --main Bench.Main
+```

--- a/bench/Main.purs
+++ b/bench/Main.purs
@@ -1,0 +1,75 @@
+-- | # Benchmarking
+-- |
+-- |     spago run --main Bench.Main
+-- |
+-- | This benchmark suite is intended to guide changes to this package so that
+-- | we can compare the benchmarks of different commits.
+
+
+module Bench.Main where
+
+import Prelude
+
+import Data.Array (fold, replicate)
+import Data.List (manyRec)
+import Data.List.Types (List)
+import Effect (Effect)
+import Effect.Console (log)
+import Performance.Minibench (benchWith)
+import Text.Parsing.StringParser (Parser, runParser)
+import Text.Parsing.StringParser.CodePoints as StringParser.CodePoints
+import Text.Parsing.StringParser.CodeUnits as StringParser.CodeUnits
+
+string23 :: String
+string23 = "23"
+
+string23_2 :: String
+string23_2 = fold $ replicate 2 string23
+
+string23_10000 :: String
+string23_10000 = fold $ replicate 10000 string23
+
+parse23DigitPoints :: Parser (List Char)
+parse23DigitPoints = manyRec StringParser.CodePoints.anyDigit
+
+parse23DigitUnits :: Parser (List Char)
+parse23DigitUnits = manyRec StringParser.CodeUnits.anyDigit
+
+parse23StringPoints :: Parser (List String)
+parse23StringPoints = manyRec $ StringParser.CodePoints.string "23"
+
+parse23StringUnits :: Parser (List String)
+parse23StringUnits = manyRec $ StringParser.CodeUnits.string "23"
+
+parse23RegexPoints :: Parser (List String)
+parse23RegexPoints = manyRec $ StringParser.CodePoints.regex """\d\d"""
+
+parse23RegexUnits :: Parser (List String)
+parse23RegexUnits = manyRec $ StringParser.CodeUnits.string """\d\d"""
+
+main :: Effect Unit
+main = do
+  -- log $ show $ runParser string23_2 parse23
+  -- log $ show $ Regex.match pattern23 string23_2
+  -- log $ show $ runParser stringSkidoo_2 parseSkidoo
+  -- log $ show $ Regex.match patternSkidoo stringSkidoo_2
+  log "StringParser.runParser parse23DigitPoints"
+  benchWith 20
+    $ \_ -> runParser parse23DigitPoints string23_10000
+  log "StringParser.runParser parse23DigitUnits"
+  benchWith 200
+    $ \_ -> runParser parse23DigitUnits string23_10000
+
+  log "StringParser.runParser parse23StringPoints"
+  benchWith 20
+    $ \_ -> runParser parse23StringPoints string23_10000
+  log "StringParser.runParser parse23StringUnits"
+  benchWith 200
+    $ \_ -> runParser parse23StringUnits string23_10000
+
+  log "StringParser.runParser parse23RegexPoints"
+  benchWith 20
+    $ \_ -> runParser parse23RegexPoints string23_10000
+  log "StringParser.runParser parse23RegexUnits"
+  benchWith 200
+    $ \_ -> runParser parse23RegexUnits string23_10000

--- a/spago.dhall
+++ b/spago.dhall
@@ -11,6 +11,7 @@
   , "foldable-traversable"
   , "lists"
   , "maybe"
+  , "minibench"
   , "nonempty"
   , "prelude"
   , "psci-support"
@@ -19,5 +20,5 @@
   , "unfoldable"
   ]
 , packages = ./packages.dhall
-, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+, sources = [ "src/**/*.purs", "test/**/*.purs", "bench/**/*.purs" ]
 }


### PR DESCRIPTION
**Description of the change**
I added a benchmark module akin to the one from `parsing`. May help in validating a fix for https://github.com/purescript-contrib/purescript-string-parsers/issues/77 and keep track of performance further down the line. @jamesdbrock 

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
