### PR TITLE
Use slices instead of cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Issue #77: Fix CodePoint parser quadratic performance (#83 by @chtenb). The parser now tracks the remaining unparsed substring. This change is breaking, but will trigger compile errors in all places where this definition is used.
 
 New features:
 
 Bugfixes:
-- Issue #77: Fix CodePoint parser quadratic performance (#83 by @chtenb)
 - Do not export `chainl'` and `chainr'` helper functions (#84 by @chtenb)
 - Fix semantics of endBy and sepEndBy parser combinators (#84 by @chtenb)
 - Issue #69: Fix regex parser to always wrap pattern inside `^(..)` (#80 by @chtenb)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Issue #77: Fix CodePoint parser quadratic performance (#83 by @chtenb)
 - Do not export `chainl'` and `chainr'` helper functions (#84 by @chtenb)
 - Fix semantics of endBy and sepEndBy parser combinators (#84 by @chtenb)
 - Issue #69: Fix regex parser to always wrap pattern inside `^(..)` (#80 by @chtenb)

--- a/bench/Main.purs
+++ b/bench/Main.purs
@@ -5,7 +5,6 @@
 -- | This benchmark suite is intended to guide changes to this package so that
 -- | we can compare the benchmarks of different commits.
 
-
 module Bench.Main where
 
 import Prelude
@@ -54,21 +53,21 @@ main = do
   -- log $ show $ runParser stringSkidoo_2 parseSkidoo
   -- log $ show $ Regex.match patternSkidoo stringSkidoo_2
   log "StringParser.runParser parse23DigitPoints"
-  benchWith 20
+  benchWith 200
     $ \_ -> runParser parse23DigitPoints string23_10000
   log "StringParser.runParser parse23DigitUnits"
   benchWith 200
     $ \_ -> runParser parse23DigitUnits string23_10000
 
   log "StringParser.runParser parse23StringPoints"
-  benchWith 20
+  benchWith 200
     $ \_ -> runParser parse23StringPoints string23_10000
   log "StringParser.runParser parse23StringUnits"
   benchWith 200
     $ \_ -> runParser parse23StringUnits string23_10000
 
   log "StringParser.runParser parse23RegexPoints"
-  benchWith 20
+  benchWith 200
     $ \_ -> runParser parse23RegexPoints string23_10000
   log "StringParser.runParser parse23RegexUnits"
   benchWith 200

--- a/bench/Main.purs
+++ b/bench/Main.purs
@@ -45,7 +45,7 @@ parse23RegexPoints :: Parser (List String)
 parse23RegexPoints = manyRec $ StringParser.CodePoints.regex """\d\d"""
 
 parse23RegexUnits :: Parser (List String)
-parse23RegexUnits = manyRec $ StringParser.CodeUnits.string """\d\d"""
+parse23RegexUnits = manyRec $ StringParser.CodeUnits.regex """\d\d"""
 
 main :: Effect Unit
 main = do

--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -100,7 +100,6 @@ fail error = Parser \{ posFromStart } -> Left { pos: posFromStart, error }
 -- |
 -- | `try p` backtracks even if input was consumed.
 try :: forall a. Parser a -> Parser a
--- try (Parser p) = Parser \(s@{ pos }) -> lmap (_ { pos = pos }) (p s)
 try (Parser p) = Parser \s ->
   case p s of
     Left { error } -> Left { pos: s.posFromStart, error }

--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -9,7 +9,6 @@ import Control.MonadPlus (class MonadPlus, class MonadZero, class Alternative)
 import Control.Monad.Rec.Class (class MonadRec, tailRecM, Step(..))
 import Control.Plus (class Plus, class Alt)
 import Control.Lazy (class Lazy)
-import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
 
 -- | A position in an input string.

--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -15,15 +15,14 @@ import Data.Either (Either(..))
 -- | A position in an input string.
 type Pos = Int
 
--- | Strings are represented as a string with an index from the
+-- | Strings are represented as a substring with an index from the
 -- | start of the string.
 -- |
--- | `{ str: s, pos: n }` is interpreted as the substring of `s`
--- | starting at index n.
+-- | `{ str: s, pos: n }` is interpreted as the substring `s`
+-- | starting at index n of the original string.
 -- |
--- | This allows us to avoid repeatedly finding substrings
--- | every time we match a character.
-type PosString = { str :: String, pos :: Pos }
+-- | The pos is only kept for error messaging.
+type PosString = { substr :: String, posFromStart :: Pos }
 
 -- | The type of parsing errors.
 type ParseError = { error :: String, pos :: Pos }
@@ -43,7 +42,7 @@ unParser (Parser p) = p
 -- | Run a parser for an input string. See also `printParserError`
 -- | and `unParser` for more flexible usages.
 runParser :: forall a. Parser a -> String -> Either ParseError a
-runParser (Parser p) s = map _.result (p { str: s, pos: 0 })
+runParser (Parser p) s = map _.result (p { substr: s, posFromStart: 0 })
 
 -- | Prints a ParseError's the error message and the position of the error.
 printParserError :: ParseError -> String
@@ -65,7 +64,7 @@ instance altParser :: Alt Parser where
   alt (Parser p1) (Parser p2) = Parser \s ->
     case p1 s of
       Left { error, pos }
-        | s.pos == pos -> p2 s
+        | s.posFromStart == pos -> p2 s
         | otherwise -> Left { error, pos }
       right -> right
 
@@ -92,17 +91,28 @@ instance monadRecParser :: MonadRec Parser where
     split { result: Done b, suffix } = Done { result: b, suffix }
 
 instance lazyParser :: Lazy (Parser a) where
-  defer f = Parser $ \str -> unParser (f unit) str
+  defer f = Parser \str -> unParser (f unit) str
 
 -- | Fail with the specified message.
 fail :: forall a. String -> Parser a
-fail error = Parser \{ pos } -> Left { pos, error }
+fail error = Parser \{ posFromStart } -> Left { pos: posFromStart, error }
 
 -- | In case of error, the default behavior is to backtrack if no input was consumed.
 -- |
 -- | `try p` backtracks even if input was consumed.
 try :: forall a. Parser a -> Parser a
-try (Parser p) = Parser \(s@{ pos }) -> lmap (_ { pos = pos }) (p s)
+-- try (Parser p) = Parser \(s@{ pos }) -> lmap (_ { pos = pos }) (p s)
+try (Parser p) = Parser \s ->
+  case p s of
+    Left { error } -> Left { pos: s.posFromStart, error }
+    right -> right
+
+-- | Read ahead without consuming input.
+lookAhead :: forall a. Parser a -> Parser a
+lookAhead (Parser p) = Parser \s ->
+  case p s of
+    Right { result } -> Right { result, suffix: s }
+    left -> left
 
 instance semigroupParser :: Semigroup a => Semigroup (Parser a) where
   append = lift2 append

--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -106,13 +106,6 @@ try (Parser p) = Parser \s ->
     Left { error } -> Left { pos: s.posFromStart, error }
     right -> right
 
--- | Read ahead without consuming input.
-lookAhead :: forall a. Parser a -> Parser a
-lookAhead (Parser p) = Parser \s ->
-  case p s of
-    Right { result } -> Right { result, suffix: s }
-    left -> left
-
 instance semigroupParser :: Semigroup a => Semigroup (Parser a) where
   append = lift2 append
 

--- a/src/Text/Parsing/StringParser.purs
+++ b/src/Text/Parsing/StringParser.purs
@@ -17,11 +17,11 @@ type Pos = Int
 -- | Strings are represented as a substring with an index from the
 -- | start of the string.
 -- |
--- | `{ str: s, pos: n }` is interpreted as the substring `s`
+-- | `{ substring: s, position: n }` is interpreted as the substring `s`
 -- | starting at index n of the original string.
 -- |
--- | The pos is only kept for error messaging.
-type PosString = { substr :: String, posFromStart :: Pos }
+-- | The position is only kept for error messaging.
+type PosString = { substring :: String, position :: Pos }
 
 -- | The type of parsing errors.
 type ParseError = { error :: String, pos :: Pos }
@@ -41,7 +41,7 @@ unParser (Parser p) = p
 -- | Run a parser for an input string. See also `printParserError`
 -- | and `unParser` for more flexible usages.
 runParser :: forall a. Parser a -> String -> Either ParseError a
-runParser (Parser p) s = map _.result (p { substr: s, posFromStart: 0 })
+runParser (Parser p) s = map _.result (p { substring: s, position: 0 })
 
 -- | Prints a ParseError's the error message and the position of the error.
 printParserError :: ParseError -> String
@@ -63,7 +63,7 @@ instance altParser :: Alt Parser where
   alt (Parser p1) (Parser p2) = Parser \s ->
     case p1 s of
       Left { error, pos }
-        | s.posFromStart == pos -> p2 s
+        | s.position == pos -> p2 s
         | otherwise -> Left { error, pos }
       right -> right
 
@@ -94,7 +94,7 @@ instance lazyParser :: Lazy (Parser a) where
 
 -- | Fail with the specified message.
 fail :: forall a. String -> Parser a
-fail error = Parser \{ posFromStart } -> Left { pos: posFromStart, error }
+fail error = Parser \{ position } -> Left { pos: position, error }
 
 -- | In case of error, the default behavior is to backtrack if no input was consumed.
 -- |
@@ -102,7 +102,7 @@ fail error = Parser \{ posFromStart } -> Left { pos: posFromStart, error }
 try :: forall a. Parser a -> Parser a
 try (Parser p) = Parser \s ->
   case p s of
-    Left { error } -> Left { pos: s.posFromStart, error }
+    Left { error } -> Left { pos: s.position, error }
     right -> right
 
 instance semigroupParser :: Semigroup a => Semigroup (Parser a) where

--- a/src/Text/Parsing/StringParser/CodePoints.purs
+++ b/src/Text/Parsing/StringParser/CodePoints.purs
@@ -37,6 +37,7 @@ import Data.String.Regex as Regex
 import Data.String.Regex.Flags (noFlags)
 import Text.Parsing.StringParser (Parser(..), try, fail)
 import Text.Parsing.StringParser.Combinators (many, (<?>))
+import Text.Parsing.StringParser.CodeUnits as CodeUnitsParser
 
 -- | Match the end of the file.
 eof :: Parser Unit
@@ -59,7 +60,7 @@ anyChar = Parser \{ substr, posFromStart } ->
 -- | Match any digit.
 anyDigit :: Parser Char
 anyDigit = try do
-  c <- anyChar
+  c <- CodeUnitsParser.anyChar
   if c >= '0' && c <= '9' then pure c
   else fail $ "Character " <> show c <> " is not a digit"
 
@@ -105,14 +106,14 @@ noneOf = satisfy <<< flip notElem
 -- | Match any lower case character.
 lowerCaseChar :: Parser Char
 lowerCaseChar = try do
-  c <- anyChar
+  c <- CodeUnitsParser.anyChar
   if toCharCode c `elem` (97 .. 122) then pure c
   else fail $ "Expected a lower case character but found " <> show c
 
 -- | Match any upper case character.
 upperCaseChar :: Parser Char
 upperCaseChar = try do
-  c <- anyChar
+  c <- CodeUnitsParser.anyChar
   if toCharCode c `elem` (65 .. 90) then pure c
   else fail $ "Expected an upper case character but found " <> show c
 

--- a/src/Text/Parsing/StringParser/CodePoints.purs
+++ b/src/Text/Parsing/StringParser/CodePoints.purs
@@ -51,7 +51,7 @@ anyChar :: Parser Char
 anyChar = Parser \{ substr, posFromStart } ->
   case SCP.codePointAt 0 substr of
     Just cp -> case toChar cp of
-      Just chr -> Right { result: chr, suffix: { substr: SCP.drop 1 substr, posFromStart: posFromStart + 1 } }
+      Just chr -> Right { result: chr, suffix: { substr: SCP.drop 1 substr, posFromStart: posFromStart + SCU.length (SCP.singleton cp) } }
       Nothing -> Left { pos: posFromStart, error: "CodePoint " <> show cp <> " is not a character" }
     Nothing -> Left { pos: posFromStart, error: "Unexpected EOF" }
   where

--- a/src/Text/Parsing/StringParser/CodePoints.purs
+++ b/src/Text/Parsing/StringParser/CodePoints.purs
@@ -43,17 +43,17 @@ import Text.Parsing.StringParser.CodeUnits as CodeUnitsParser
 eof :: Parser Unit
 eof = Parser \s ->
   case s of
-    { substr, posFromStart } | 0 < SCP.length substr -> Left { pos: posFromStart, error: "Expected EOF" }
+    { substring, position } | 0 < SCP.length substring -> Left { pos: position, error: "Expected EOF" }
     _ -> Right { result: unit, suffix: s }
 
 -- | Match any character.
 anyChar :: Parser Char
-anyChar = Parser \{ substr, posFromStart } ->
-  case SCP.codePointAt 0 substr of
+anyChar = Parser \{ substring, position } ->
+  case SCP.codePointAt 0 substring of
     Just cp -> case toChar cp of
-      Just chr -> Right { result: chr, suffix: { substr: SCP.drop 1 substr, posFromStart: posFromStart + 1 } }
-      Nothing -> Left { pos: posFromStart, error: "CodePoint " <> show cp <> " is not a character" }
-    Nothing -> Left { pos: posFromStart, error: "Unexpected EOF" }
+      Just chr -> Right { result: chr, suffix: { substring: SCP.drop 1 substring, position: position + 1 } }
+      Nothing -> Left { pos: position, error: "CodePoint " <> show cp <> " is not a character" }
+    Nothing -> Left { pos: position, error: "Unexpected EOF" }
   where
   toChar = fromCharCode <<< fromEnum
 
@@ -66,13 +66,13 @@ anyDigit = try do
 
 -- | Match the specified string.
 string :: String -> Parser String
-string pattern = Parser \{ substr, posFromStart } ->
+string pattern = Parser \{ substring, position } ->
   let
     length = SCP.length pattern
-    { before, after } = SCP.splitAt length substr
+    { before, after } = SCP.splitAt length substring
   in
-    if before == pattern then Right { result: pattern, suffix: { substr: after, posFromStart: posFromStart + length } }
-    else Left { pos: posFromStart, error: "Expected '" <> pattern <> "'." }
+    if before == pattern then Right { result: pattern, suffix: { substring: after, position: position + length } }
+    else Left { pos: position, error: "Expected '" <> pattern <> "'." }
 
 -- | Match a character satisfying the given predicate.
 satisfy :: (Char -> Boolean) -> Parser Char
@@ -138,9 +138,9 @@ regex pat =
   pattern = "^(" <> pat <> ")"
 
   matchRegex :: Regex.Regex -> Parser String
-  matchRegex r = Parser \{ substr, posFromStart } -> do
-    case NEA.head <$> Regex.match r substr of
+  matchRegex r = Parser \{ substring, position } -> do
+    case NEA.head <$> Regex.match r substring of
       Just (Just matched) ->
-        Right { result: matched, suffix: { substr: SCP.drop (SCP.length matched) substr, posFromStart: posFromStart + SCP.length matched } }
+        Right { result: matched, suffix: { substring: SCP.drop (SCP.length matched) substring, position: position + SCP.length matched } }
       _ ->
-        Left { pos: posFromStart, error: "no match" }
+        Left { pos: position, error: "no match" }

--- a/src/Text/Parsing/StringParser/CodePoints.purs
+++ b/src/Text/Parsing/StringParser/CodePoints.purs
@@ -43,7 +43,7 @@ import Text.Parsing.StringParser.CodeUnits as CodeUnitsParser
 eof :: Parser Unit
 eof = Parser \s ->
   case s of
-    { substr, posFromStart } | 0 < SCU.length substr -> Left { pos: posFromStart, error: "Expected EOF" }
+    { substr, posFromStart } | 0 < SCP.length substr -> Left { pos: posFromStart, error: "Expected EOF" }
     _ -> Right { result: unit, suffix: s }
 
 -- | Match any character.
@@ -51,7 +51,7 @@ anyChar :: Parser Char
 anyChar = Parser \{ substr, posFromStart } ->
   case SCP.codePointAt 0 substr of
     Just cp -> case toChar cp of
-      Just chr -> Right { result: chr, suffix: { substr: SCP.drop 1 substr, posFromStart: posFromStart + SCU.length (SCP.singleton cp) } }
+      Just chr -> Right { result: chr, suffix: { substr: SCP.drop 1 substr, posFromStart: posFromStart + 1 } }
       Nothing -> Left { pos: posFromStart, error: "CodePoint " <> show cp <> " is not a character" }
     Nothing -> Left { pos: posFromStart, error: "Unexpected EOF" }
   where
@@ -68,8 +68,8 @@ anyDigit = try do
 string :: String -> Parser String
 string pattern = Parser \{ substr, posFromStart } ->
   let
-    length = SCU.length pattern
-    { before, after } = SCU.splitAt length substr
+    length = SCP.length pattern
+    { before, after } = SCP.splitAt length substr
   in
     if before == pattern then Right { result: pattern, suffix: { substr: after, posFromStart: posFromStart + length } }
     else Left { pos: posFromStart, error: "Expected '" <> pattern <> "'." }
@@ -141,6 +141,6 @@ regex pat =
   matchRegex r = Parser \{ substr, posFromStart } -> do
     case NEA.head <$> Regex.match r substr of
       Just (Just matched) ->
-        Right { result: matched, suffix: { substr: SCU.drop (SCU.length matched) substr, posFromStart: posFromStart + SCU.length matched } }
+        Right { result: matched, suffix: { substr: SCP.drop (SCP.length matched) substr, posFromStart: posFromStart + SCP.length matched } }
       _ ->
         Left { pos: posFromStart, error: "no match" }

--- a/src/Text/Parsing/StringParser/CodeUnits.purs
+++ b/src/Text/Parsing/StringParser/CodeUnits.purs
@@ -32,7 +32,6 @@ import Data.Foldable (class Foldable, foldMap, elem, notElem)
 import Data.Maybe (Maybe(..))
 import Data.String.CodeUnits (charAt, singleton)
 import Data.String.CodeUnits as SCU
-import Data.String.Pattern (Pattern(..))
 import Data.String.Regex as Regex
 import Data.String.Regex.Flags (noFlags)
 import Text.Parsing.StringParser (Parser(..), try, fail)
@@ -61,10 +60,13 @@ anyDigit = try do
 
 -- | Match the specified string.
 string :: String -> Parser String
-string nt = Parser \s ->
-  case s of
-    { substr, posFromStart } | SCU.indexOf (Pattern nt) substr == Just 0 -> Right { result: nt, suffix: { substr: SCU.drop (SCU.length nt) substr, posFromStart: posFromStart + SCU.length nt } }
-    { posFromStart } -> Left { pos: posFromStart, error: "Expected '" <> nt <> "'." }
+string pattern = Parser \{ substr, posFromStart } ->
+  let
+    length = SCU.length pattern
+    { before, after } = SCU.splitAt length substr
+  in
+    if before == pattern then Right { result: pattern, suffix: { substr: after, posFromStart: posFromStart + length } }
+    else Left { pos: posFromStart, error: "Expected '" <> pattern <> "'." }
 
 -- | Match a character satisfying the given predicate.
 satisfy :: (Char -> Boolean) -> Parser Char

--- a/src/Text/Parsing/StringParser/CodeUnits.purs
+++ b/src/Text/Parsing/StringParser/CodeUnits.purs
@@ -41,15 +41,15 @@ import Text.Parsing.StringParser.Combinators (many, (<?>))
 eof :: Parser Unit
 eof = Parser \s ->
   case s of
-    { substr, posFromStart } | 0 < SCU.length substr -> Left { pos: posFromStart, error: "Expected EOF" }
+    { substring, position } | 0 < SCU.length substring -> Left { pos: position, error: "Expected EOF" }
     _ -> Right { result: unit, suffix: s }
 
 -- | Match any character.
 anyChar :: Parser Char
-anyChar = Parser \{ substr, posFromStart } ->
-  case charAt 0 substr of
-    Just chr -> Right { result: chr, suffix: { substr: SCU.drop 1 substr, posFromStart: posFromStart + 1 } }
-    Nothing -> Left { pos: posFromStart, error: "Unexpected EOF" }
+anyChar = Parser \{ substring, position } ->
+  case charAt 0 substring of
+    Just chr -> Right { result: chr, suffix: { substring: SCU.drop 1 substring, position: position + 1 } }
+    Nothing -> Left { pos: position, error: "Unexpected EOF" }
 
 -- | Match any digit.
 anyDigit :: Parser Char
@@ -60,13 +60,13 @@ anyDigit = try do
 
 -- | Match the specified string.
 string :: String -> Parser String
-string pattern = Parser \{ substr, posFromStart } ->
+string pattern = Parser \{ substring, position } ->
   let
     length = SCU.length pattern
-    { before, after } = SCU.splitAt length substr
+    { before, after } = SCU.splitAt length substring
   in
-    if before == pattern then Right { result: pattern, suffix: { substr: after, posFromStart: posFromStart + length } }
-    else Left { pos: posFromStart, error: "Expected '" <> pattern <> "'." }
+    if before == pattern then Right { result: pattern, suffix: { substring: after, position: position + length } }
+    else Left { pos: position, error: "Expected '" <> pattern <> "'." }
 
 -- | Match a character satisfying the given predicate.
 satisfy :: (Char -> Boolean) -> Parser Char
@@ -132,9 +132,9 @@ regex pat =
   pattern = "^(" <> pat <> ")"
 
   matchRegex :: Regex.Regex -> Parser String
-  matchRegex r = Parser \{ substr, posFromStart } -> do
-    case NEA.head <$> Regex.match r substr of
+  matchRegex r = Parser \{ substring, position } -> do
+    case NEA.head <$> Regex.match r substring of
       Just (Just matched) ->
-        Right { result: matched, suffix: { substr: SCU.drop (SCU.length matched) substr, posFromStart: posFromStart + SCU.length matched } }
+        Right { result: matched, suffix: { substring: SCU.drop (SCU.length matched) substring, position: position + SCU.length matched } }
       _ ->
-        Left { pos: posFromStart, error: "no match" }
+        Left { pos: position, error: "no match" }

--- a/src/Text/Parsing/StringParser/Combinators.purs
+++ b/src/Text/Parsing/StringParser/Combinators.purs
@@ -21,6 +21,7 @@ module Text.Parsing.StringParser.Combinators
   , choice
   , manyTill
   , many1Till
+  , lookAhead
   , module Control.Lazy
   ) where
 
@@ -29,13 +30,21 @@ import Prelude
 import Control.Alt ((<|>))
 import Control.Lazy (fix)
 import Control.Monad.Rec.Class (Step(..), tailRecM)
+import Data.Either (Either(..))
 import Data.Foldable (class Foldable, foldl)
 import Data.List (List(..), manyRec)
 import Data.List.NonEmpty (NonEmptyList(..))
 import Data.List.NonEmpty as NEL
 import Data.Maybe (Maybe(..))
 import Data.NonEmpty ((:|))
-import Text.Parsing.StringParser (Parser, fail)
+import Text.Parsing.StringParser (Parser(..), fail)
+
+-- | Read ahead without consuming input.
+lookAhead :: forall a. Parser a -> Parser a
+lookAhead (Parser p) = Parser \s ->
+  case p s of
+    Right { result } -> Right { result, suffix: s }
+    left -> left
 
 -- | Match zero or more times.
 many :: forall a. Parser a -> Parser (List a)

--- a/src/Text/Parsing/StringParser/Combinators.purs
+++ b/src/Text/Parsing/StringParser/Combinators.purs
@@ -1,7 +1,6 @@
 -- | This module defines combinators for building string parsers.
 module Text.Parsing.StringParser.Combinators
-  ( lookAhead
-  , many
+  ( many
   , many1
   , withError
   , (<?>)
@@ -32,21 +31,13 @@ import Prelude
 import Control.Alt ((<|>))
 import Control.Lazy (fix)
 import Control.Monad.Rec.Class (Step(..), tailRecM)
-import Data.Either (Either(..))
 import Data.Foldable (class Foldable, foldl)
 import Data.List (List(..), manyRec)
 import Data.List.NonEmpty (NonEmptyList(..))
 import Data.List.NonEmpty as NEL
 import Data.Maybe (Maybe(..))
 import Data.NonEmpty ((:|))
-import Text.Parsing.StringParser (Parser(..), fail)
-
--- | Read ahead without consuming input.
-lookAhead :: forall a. Parser a -> Parser a
-lookAhead (Parser p) = Parser \s ->
-  case p s of
-    Right { result } -> Right { result, suffix: s }
-    left -> left
+import Text.Parsing.StringParser (Parser, fail)
 
 -- | Match zero or more times.
 many :: forall a. Parser a -> Parser (List a)

--- a/test/CodePoints.purs
+++ b/test/CodePoints.purs
@@ -120,7 +120,7 @@ testCodePoints = do
   assert $ expectResult "\x458CA" (string "\x458CA" <* string ")" <* eof) "\x458CA)"
   assert $ expectResult '\xEEE2' (char '\xEEE2' <* eof) "\xEEE2"
   assert $ expectPosition 1 anyChar "\xEEE2"
-  assert $ expectPosition 2 anyChar "\x458CA"
+  assert $ expectPosition 1 anyChar "\x458CA"
 
   log "Running overflow tests (may take a while)"
 

--- a/test/CodePoints.purs
+++ b/test/CodePoints.purs
@@ -72,6 +72,12 @@ parseFail p input = isLeft $ runParser p input
 expectResult :: forall a. Eq a => a -> Parser a -> String -> Boolean
 expectResult res p input = runParser p input == Right res
 
+expectPosition :: forall a. Int -> Parser a -> String -> Boolean
+expectPosition pos p input =
+  case testParser p input of
+    Right r -> r.suffix.posFromStart == pos
+    Left _ -> false
+
 testCodePoints :: Effect Unit
 testCodePoints = do
 
@@ -113,6 +119,8 @@ testCodePoints = do
   assert $ expectResult "\x458CA" (string "\x458CA" <* char ']' <* eof) "\x458CA]"
   assert $ expectResult "\x458CA" (string "\x458CA" <* string ")" <* eof) "\x458CA)"
   assert $ expectResult '\xEEE2' (char '\xEEE2' <* eof) "\xEEE2"
+  assert $ expectPosition 1 anyChar "\xEEE2"
+  assert $ expectPosition 2 anyChar "\x458CA"
 
   log "Running overflow tests (may take a while)"
 

--- a/test/CodePoints.purs
+++ b/test/CodePoints.purs
@@ -61,7 +61,7 @@ tryTest =
     (string "aa" <> string "cc")
 
 testParser :: forall a. Parser a -> String -> Either ParseError { result :: a, suffix :: PosString }
-testParser (Parser p) s = p { substr: s, posFromStart: 0 }
+testParser (Parser p) s = p { substring: s, position: 0 }
 
 canParse :: forall a. Parser a -> String -> Boolean
 canParse p input = isRight $ runParser p input
@@ -75,7 +75,7 @@ expectResult res p input = runParser p input == Right res
 expectPosition :: forall a. Int -> Parser a -> String -> Boolean
 expectPosition pos p input =
   case testParser p input of
-    Right r -> r.suffix.posFromStart == pos
+    Right r -> r.suffix.position == pos
     Left _ -> false
 
 testCodePoints :: Effect Unit

--- a/test/CodePoints.purs
+++ b/test/CodePoints.purs
@@ -15,7 +15,7 @@ import Data.Unfoldable (replicate)
 import Effect (Effect)
 import Effect.Class.Console (log)
 import Test.Assert (assert', assert)
-import Text.Parsing.StringParser (Parser, runParser, try)
+import Text.Parsing.StringParser (ParseError, Parser(..), PosString, runParser, try)
 import Text.Parsing.StringParser.CodePoints (anyDigit, char, eof, string, anyChar, regex)
 import Text.Parsing.StringParser.Combinators (many1, endBy1, sepBy1, optionMaybe, many, manyTill, many1Till, chainl, fix, between)
 import Text.Parsing.StringParser.Expr (Assoc(..), Operator(..), buildExprParser)
@@ -59,6 +59,9 @@ tryTest :: Parser String
 tryTest =
   try (string "aa" <> string "bb") <|>
     (string "aa" <> string "cc")
+
+testParser :: forall a. Parser a -> String -> Either ParseError { result :: a, suffix :: PosString }
+testParser (Parser p) s = p { substr: s, posFromStart: 0 }
 
 canParse :: forall a. Parser a -> String -> Boolean
 canParse p input = isRight $ runParser p input

--- a/test/Examples.purs
+++ b/test/Examples.purs
@@ -8,9 +8,9 @@ import Data.Foldable (fold, foldl, sum)
 import Data.List.Types (NonEmptyList)
 import Effect (Effect)
 import Effect.Console (log, logShow)
-import Text.Parsing.StringParser (Parser, fail, runParser, unParser)
+import Text.Parsing.StringParser (Parser, fail, lookAhead, runParser, unParser)
 import Text.Parsing.StringParser.CodePoints (anyChar, char, eof, regex, skipSpaces, string)
-import Text.Parsing.StringParser.Combinators (between, endBy1, lookAhead, many, many1, sepBy1, (<?>))
+import Text.Parsing.StringParser.Combinators (between, endBy1, many, many1, sepBy1, (<?>))
 
 -- Serves only to make this file runnable
 main :: Effect Unit
@@ -234,7 +234,7 @@ doBoth parserName parser content = do
 doUnParser :: forall a. Show a => String -> Parser a -> String -> Effect Unit
 doUnParser parserName parser content = do
   log $ "(unParser) Parsing content with '" <> parserName <> "'"
-  case unParser parser { str: content, pos: 0 } of
+  case unParser parser { substr: content, posFromStart: 0 } of
     Left rec -> log $ "Position: " <> show rec.pos
       <>
         "\n\

--- a/test/Examples.purs
+++ b/test/Examples.purs
@@ -234,7 +234,7 @@ doBoth parserName parser content = do
 doUnParser :: forall a. Show a => String -> Parser a -> String -> Effect Unit
 doUnParser parserName parser content = do
   log $ "(unParser) Parsing content with '" <> parserName <> "'"
-  case unParser parser { substr: content, posFromStart: 0 } of
+  case unParser parser { substring: content, position: 0 } of
     Left rec -> log $ "Position: " <> show rec.pos
       <>
         "\n\

--- a/test/Examples.purs
+++ b/test/Examples.purs
@@ -8,9 +8,9 @@ import Data.Foldable (fold, foldl, sum)
 import Data.List.Types (NonEmptyList)
 import Effect (Effect)
 import Effect.Console (log, logShow)
-import Text.Parsing.StringParser (Parser, fail, lookAhead, runParser, unParser)
+import Text.Parsing.StringParser (Parser, fail, runParser, unParser)
 import Text.Parsing.StringParser.CodePoints (anyChar, char, eof, regex, skipSpaces, string)
-import Text.Parsing.StringParser.Combinators (between, endBy1, many, many1, sepBy1, (<?>))
+import Text.Parsing.StringParser.Combinators (between, lookAhead, endBy1, many, many1, sepBy1, (<?>))
 
 -- Serves only to make this file runnable
 main :: Effect Unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,8 +9,9 @@ import Test.CodeUnits (testCodeUnits)
 
 main :: Effect Unit
 main = do
-  log "Testing CodePoint parsing\n"
-  testCodePoints
 
-  log "\n\nTesting CodeUnit parsing\n"
+  log "Testing CodeUnit parsing\n"
   testCodeUnits
+
+  log "\n\nTesting CodePoint parsing\n"
+  testCodePoints


### PR DESCRIPTION
Proof of concept to fix #77. This change would be breaking because it changes the underlying representation.

- [x] Use slices instead of cursors
- [x] Do a startsWith check in the string parser instead of a call to `indexOf`
- [x] Make the CodePoint parsers `anyDigit`, `anyLetter` and derivatives use the CodeUnit version of `anyChar` for speed
- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close

| Benchmark before | Benchmark after |
|:---:|:---:|
| StringParser.runParser parse23AnyCharPoints | StringParser.runParser parse23AnyCharPoints |
| mean   = 1.01 s | mean   = 16.14 ms |
| stddev = 51.48 ms | stddev = 13.64 ms |
| min    = 963.28 ms | min    = 8.55 ms |
| max    = 1.16 s | max    = 53.29 ms |
| StringParser.runParser parse23AnyCharUnits | StringParser.runParser parse23AnyCharUnits |
| mean   = 8.53 ms | mean   = 8.73 ms |
| stddev = 2.77 ms | stddev = 2.95 ms |
| min    = 7.25 ms | min    = 7.24 ms |
| max    = 38.72 ms | max    = 40.49 ms |
| StringParser.runParser parse23DigitPoints | StringParser.runParser parse23DigitPoints |
| mean   = 994.93 ms | mean   = 10.02 ms |
| stddev = 16.97 ms | stddev = 1.61 ms |
| min    = 974.33 ms | min    = 8.65 ms |
| max    = 1.04 s | max    = 23.21 ms |
| StringParser.runParser parse23DigitUnits | StringParser.runParser parse23DigitUnits |
| mean   = 10.87 ms | mean   = 10.28 ms |
| stddev = 1.78 ms | stddev = 1.56 ms |
| min    = 9.51 ms | min    = 8.71 ms |
| max    = 23.81 ms | max    = 22.51 ms |
| StringParser.runParser parse23StringPoints | StringParser.runParser parse23StringPoints |
| mean   = 1.06 s | mean   = 6.91 ms |
| stddev = 16.93 ms | stddev = 954.29 μs |
| min    = 1.01 s | min    = 5.80 ms |
| max    = 1.09 s | max    = 15.04 ms |
| StringParser.runParser parse23StringUnits | StringParser.runParser parse23StringUnits |
| mean   = 4.52 ms | mean   = 4.40 ms |
| stddev = 958.15 μs | stddev = 757.47 μs |
| min    = 3.81 ms | min    = 3.61 ms |
| max    = 13.09 ms | max    = 8.46 ms |
| StringParser.runParser parse23RegexPoints | StringParser.runParser parse23RegexPoints |
| mean   = 1.03 s | mean   = 11.77 ms |
| stddev = 44.87 ms | stddev = 2.11 ms |
| min    = 978.55 ms | min    = 9.76 ms |
| max    = 1.15 s | max    = 28.49 ms |
| StringParser.runParser parse23RegexUnits | StringParser.runParser parse23RegexUnits |
| mean   = 5.90 ms | mean   = 5.88 ms |
| stddev = 900.33 μs | stddev = 1.05 ms |
| min    = 4.89 ms | min    = 4.93 ms |
| max    = 12.99 ms | max    = 16.71 m |
