### PR TITLE
Fix spago package sets' upstream url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- fix spago package sets' upstream url
 
 Other improvements:
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.15/src/packages.dhall
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220822/packages.dhall
+        sha256:908b4ffbfba37a0a4edf806513a555d0dbcdd0cde7abd621f8d018d2e8ecf828
 
 in  upstream


### PR DESCRIPTION
It seems the CI fails because of the spago packeage sets' upsrteram url is outdated.
So I fixed it. Please review if you are at convenience.

Error messages on CI ↓
```
Run spago install
spago: 
Error: Remote file not found

HTTP status code: 404

URL: https://raw.githubusercontent.com/purescript/package-sets/prepare-0.15/src/packages.dhall

Message:

1│ 404: Not Found

Error: Process completed with exit code 1.
```
---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
