### PR TITLE
Make sepEndBy stack safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New features:
 
 Bugfixes:
 - fix spago package sets' upstream url
+- make `sepEndBy` stack safe
 
 Other improvements:
 

--- a/src/StringParser/Combinators.purs
+++ b/src/StringParser/Combinators.purs
@@ -142,11 +142,9 @@ sepEndBy p sep = (sepEndBy1 p sep <#> NEL.toList) <|> (sep $> Nil) <|> pure Nil
 sepEndBy1 :: forall a sep. Parser a -> Parser sep -> Parser (NonEmptyList a)
 sepEndBy1 p sep = do
   a <- p
-  ( do
-      _ <- sep
-      as <- sepEndBy p sep
-      pure (cons' a as)
-  ) <|> pure (NEL.singleton a)
+  as <- many $ try (sep *> p)
+  _ <- optional sep
+  pure (cons' a as)
 
 -- | Parse zero or more separated values, ending with a separator.
 endBy :: forall a sep. Parser a -> Parser sep -> Parser (List a)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,6 +7,7 @@ import Effect.Console (log)
 import Test.CodePoints (testCodePoints)
 import Test.CodeUnits (testCodeUnits)
 import Test.BasicSpecs (runTestCases)
+import Test.StackSafeCombinators (testStackSafeCombinators)
 
 main :: Effect Unit
 main = do
@@ -18,3 +19,6 @@ main = do
 
   log "\n\nTesting CodePoint parsing\n"
   testCodePoints
+
+  log "\n\nTesting stack safety of combinators\n"
+  testStackSafeCombinators

--- a/test/StackSafeCombinators.purs
+++ b/test/StackSafeCombinators.purs
@@ -1,0 +1,19 @@
+module Test.StackSafeCombinators where
+
+import Prelude
+
+import Data.Array (replicate)
+import Data.Either (isRight)
+import Data.String.Common as SC
+import Effect (Effect)
+import Effect.Class.Console (log)
+import StringParser (Parser, char, runParser, sepEndBy)
+import Test.Assert (assert)
+
+canParse :: forall a. Parser a -> String -> Boolean
+canParse p input = isRight $ runParser p input
+
+testStackSafeCombinators :: Effect Unit
+testStackSafeCombinators = do
+  log "Running overflow tests"
+  assert $ canParse (sepEndBy (char 'a') (char ';')) (SC.joinWith ";" $ replicate 100000 "a")


### PR DESCRIPTION
I encountered stack overflow when I used `sepEndBy` for large data.
It seemed to be caused by `sepEndBy` and `sepEndBy1` are calling each other.
So I added a test and fixed `sepEndBy1` using stack safe `many`. 

It seems that `chainl` and `chainr` should also be fixed. 
However I fixed only `sepEndBy` with this PR because these functions are a little complicated to me.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
